### PR TITLE
Add extra View constructor so it can be included directly in XML

### DIFF
--- a/src/pl/polidea/view/ZoomView.java
+++ b/src/pl/polidea/view/ZoomView.java
@@ -69,6 +69,10 @@ public class ZoomView extends FrameLayout {
         super(context);
     }
 
+    public ZoomView(final Context context, AttributeSet attributes) {
+        super(context, attributes);
+    }
+
     public float getZoom() {
         return zoom;
     }


### PR DESCRIPTION
Solves this issue: https://github.com/Polidea/android-zoom-view/issues/2

Example XML usage:
        <pl.polidea.view.ZoomView
            android:layout_width="match_parent"
            android:layout_height="match_parent"
            />

Example stack trace from crash without this fix:

Caused by: android.view.InflateException: Binary XML file line #15: Error inflating class pl.polidea.view.ZoomView
            at android.view.LayoutInflater.createView(LayoutInflater.java:603)
            at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:696)

<snip>

```
 Caused by: java.lang.NoSuchMethodException: <init> [class android.content.Context, interface android.util.AttributeSet]
        at java.lang.Class.getConstructorOrMethod(Class.java:472)
        at java.lang.Class.getConstructor(Class.java:446)
```
